### PR TITLE
Add CocoaPods Spec

### DIFF
--- a/KGStatusBar.podspec
+++ b/KGStatusBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "KGStatusBar"
-  s.version      = "0.0.1"
+  s.version      = "1.0"
   s.summary      = "A minimal status bar for iOS."
   s.description  = <<-DESC
                       Similar to the status bar seen in the MailBox app, it covers the top status bar and appears like the message is embedded within.
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE.TXT' }
   s.author       = { "Kevin Gibbon" => "gibbon.kevin@gmail.com" }
   
-  s.source       = { :git => "https://github.com/kevingibbon/KGStatusBar.git", :commit => "6af8533916b5da5f2aa951563bfae4dfa3f2c50b" }
+  s.source       = { :git => "https://github.com/kevingibbon/KGStatusBar.git", :tag => "v1.0" }
   
   s.platform     = :ios
   s.source_files = 'KGStatusBar'

--- a/KGStatusBar.podspec
+++ b/KGStatusBar.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "KGStatusBar"
+  s.version      = "0.0.1"
+  s.summary      = "A minimal status bar for iOS."
+  s.description  = <<-DESC
+                      Similar to the status bar seen in the MailBox app, it covers the top status bar and appears like the message is embedded within.
+                     DESC
+  s.homepage     = "https://github.com/kevingibbon/KGStatusBar"
+
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE.TXT' }
+  s.author       = { "Kevin Gibbon" => "gibbon.kevin@gmail.com" }
+  
+  s.source       = { :git => "https://github.com/kevingibbon/KGStatusBar.git", :commit => "6af8533916b5da5f2aa951563bfae4dfa3f2c50b" }
+  
+  s.platform     = :ios
+  s.source_files = 'KGStatusBar'
+  s.requires_arc = true
+end


### PR DESCRIPTION
I love your project!  I added a CocoaPods spec, so that it can be packaged with CocoaPods.  CocoaPods is an Objective-C Library Dependency Manager.  If you are happy with this Podspec, I can submit the pull request to CocoaPods/Specs if you want.

I will open a code view and add a suggestion.

Thanks in advance!
